### PR TITLE
CODE RUB: Changes to the validation to keep model validation together…

### DIFF
--- a/Taarafo.Core/Services/Foundations/Comments/CommentService.cs
+++ b/Taarafo.Core/Services/Foundations/Comments/CommentService.cs
@@ -32,7 +32,8 @@ namespace Taarafo.Core.Services.Foundations.Comments
         public ValueTask<Comment> AddCommentAsync(Comment comment) =>
         TryCatch(async () =>
         {
-            ValidateCommentOnAdd(comment);
+            // ValidateCommentOnAdd(comment);
+            ValidateComment(comment, OperationsEnum.Add);
 
             return await this.storageBroker.InsertCommentAsync(comment);
         });
@@ -56,7 +57,8 @@ namespace Taarafo.Core.Services.Foundations.Comments
         public ValueTask<Comment> ModifyCommentAsync(Comment comment) =>
         TryCatch(async () =>
         {
-            ValidateCommentOnModify(comment);
+            // ValidateCommentOnModify(comment);
+            ValidateComment(comment, OperationsEnum.Modify);
 
             Comment maybeComment =
                 await this.storageBroker.SelectCommentByIdAsync(comment.Id);

--- a/Taarafo.Core/Services/OperationsEnum.cs
+++ b/Taarafo.Core/Services/OperationsEnum.cs
@@ -1,0 +1,15 @@
+﻿// ---------------------------------------------------------------
+// Copyright (c) Coalition of the Good-Hearted Engineers
+// FREE TO USE TO CONNECT THE WORLD
+// ---------------------------------------------------------------
+
+namespace Taarafo.Core.Services
+{
+    public enum OperationsEnum
+    {
+        Add,
+        Read,
+        Modify,
+        Remove
+    }
+}


### PR DESCRIPTION
@hassanhabib - Here is the code change for the validation changes to share the same logic for ADD and MODIFY.  As this is not linked with the external validation, I can't see how we would accidentally throw an exception too early since the combined result is thrown at the end of Validate(...) with the ThrowIfContainsErrors()

The only difference here is that we have added a boolean condition **applyRule** to also weigh in on the rule condition i.e. if your applyRule condition is "applyRule: operation == OperationsEnum.Modify" on an add method, the condition would always be false which would mean this rule will not qualify for the UpsertDataList

The benefit here for me here is that you don't have to (or remember to) keep the validation logic in sync at two places (ADD and MODIFY) and you can see all the rules at play for the model validation in one place.

Would be good if you could review this code change for me?