### PR TITLE
MINOR FIX: Post validation logic for updated date on modify

### DIFF
--- a/Taarafo.Core.Tests.Unit/Services/Foundations/Posts/PostServiceTests.Logic.Modify.cs
+++ b/Taarafo.Core.Tests.Unit/Services/Foundations/Posts/PostServiceTests.Logic.Modify.cs
@@ -22,7 +22,8 @@ namespace Taarafo.Core.Tests.Unit.Services.Foundations.Posts
             DateTimeOffset randomDate = GetRandomDateTimeOffset();
             Post randomPost = CreateRandomModifyPost(randomDate);
             Post inputPost = randomPost;
-            Post storagePost = inputPost;
+            Post storagePost = inputPost.DeepClone();
+            storagePost.UpdatedDate = randomPost.CreatedDate;
             Post updatedPost = inputPost;
             Post expectedPost = updatedPost.DeepClone();
             Guid postId = inputPost.Id;

--- a/Taarafo.Core/Services/Foundations/Posts/PostService.Validations.cs
+++ b/Taarafo.Core/Services/Foundations/Posts/PostService.Validations.cs
@@ -133,7 +133,7 @@ namespace Taarafo.Core.Services.Foundations.Posts
                     secondDateName: nameof(Post.CreatedDate)),
                 Parameter: nameof(Post.CreatedDate)),
 
-                (Rule: IsNotSame(
+                (Rule: IsSame(
                     firstDate: inputPost.UpdatedDate,
                     secondDate: storagePost.UpdatedDate,
                     secondDateName: nameof(Post.UpdatedDate)),


### PR DESCRIPTION
Closes #105
Fixed the validation logic.  We expect the updated date to be different to that on storage.